### PR TITLE
Add number to navigate

### DIFF
--- a/types/react-router/index.d.ts
+++ b/types/react-router/index.d.ts
@@ -153,7 +153,11 @@ export const __RouterContext: React.Context<RouteComponentProps>;
 
 export function useLocation<S = H.LocationState>(): H.Location<S>;
 
-export function useNavigate(): (path: string | number) => void;
+export function useNavigate(): (
+    path: string | number,
+    config?: Partial<{ replace: boolean; state: object }>
+) => void;
+
 
 export function useParams<Params extends { [K in keyof Params]?: string } = {}>(): { [p in keyof Params]: keyof Params[p] extends undefined ? string | undefined : string  };
 

--- a/types/react-router/index.d.ts
+++ b/types/react-router/index.d.ts
@@ -158,7 +158,6 @@ export function useNavigate(): (
     config?: Partial<{ replace: boolean; state: object }>
 ) => void;
 
-
 export function useParams<Params extends { [K in keyof Params]?: string } = {}>(): { [p in keyof Params]: keyof Params[p] extends undefined ? string | undefined : string  };
 
 export function useRouteMatch<Params extends { [K in keyof Params]?: string } = {}>(): match<Params>;

--- a/types/react-router/index.d.ts
+++ b/types/react-router/index.d.ts
@@ -153,7 +153,7 @@ export const __RouterContext: React.Context<RouteComponentProps>;
 
 export function useLocation<S = H.LocationState>(): H.Location<S>;
 
-export function useNavigate(): (path: string) => void;
+export function useNavigate(): (path: string | number) => void;
 
 export function useParams<Params extends { [K in keyof Params]?: string } = {}>(): { [p in keyof Params]: keyof Params[p] extends undefined ? string | undefined : string  };
 


### PR DESCRIPTION
navigate accepts number to go back or forward. Also it accespta a config object.
<button onClick={() => navigate(-2)}>Go 2 pages back</button>

> If you need to replace the current location instead of push a new one onto the history stack, use navigate(to, { replace: true }). If you need state, use navigate(to, { state }). 